### PR TITLE
feat: allow to copy profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,18 @@ Copy a selection in reading view while keeping the markdown formatting
 > The goal is to replace the native copy function of Obsidian. You can set the command on <kbd>CTRL</kbd> + <kbd>C</kbd> (<kbd>⌘</kbd>+<kbd>C</kbd> on MacOS)
 > Some selection doesn't work as in the native copy in Obsidian, but I didn't find a way to process the native copy function in the plugin.
 
-> **Warning**  
-> It is possible that the command doesn't work on mobile, as the use of command palette unselects the text.
-
 ## ⚙️ Settings
 
 You can adjust the way the content is copied in the settings.
 
 First, you need to set the view mode to use. You can choose between:
+
 - `reading`: Only the selected text in reading view will be edited
 - `editing` : Only the selected text in editing view will be edited
 - `all` : The selected text will be edited in both views
 
 You can also choose to add a command for each copy-mode. It will create a command for :
+
 - Reading view (with checkCallback)
 - Editing view
 - Non markdown view (canvas, database-plugin...)
@@ -32,9 +31,13 @@ You can also choose to add a command for each copy-mode. It will create a comman
 Finally, you can to choose to override the default copy (from menu and the <kbd>CTRL</kbd>/<kbd>⌘</kbd> + <kbd>C</kbd>). Pretty useful for mobile!
 
 > [!Note]
-> The default copy is disabled on canvas, so I advice you to use the command separator to set an hotkey/button for "other" view & use the default copy on markdown view (reading and LP/source mode). 
+> The default copy is disabled on canvas, so I advice you to use the command separator to set an hotkey/button for "other" view & use the default copy on markdown view (reading and LP/source mode).
 
 The reading view and editing view have ~ the same settings, but you need to set them separately. It will allow having different copy settings for each view.
+
+You can enable the overriding of native copy for each view, so it could be disabled for reading view and enabled for editing view (and vice versa).
+
+You can create "profile", that will add a command (after reloadig Obsidian), so you can create a profile for copying on Discord and use it some times.
 
 ### Common settings
 
@@ -42,30 +45,31 @@ These settings are the same for both views. As they are separate for each view, 
 It is done on purpose to prevent surprise when you use the plugin on editing view but don't want some changes.
 
 > **Info**
-> The button in the first tab "copy" will allow you to copy the settings for one view to the other. 
+> The button in the first tab "copy" will allow you to copy the settings for one view to the other.
 
 - You can change the aspect of the links:
-    - `Keep` : Don't change the link (so they will be in `[link](url)` format)
-    - `Remove all` : Remove all the links, and keep only the alias (so `[link](url)` will be `link`)
-    - `Remove only for internal links` : Remove only the internal links (so `[link](url)` will be `link` but `[link](https://example.com)` will be `[link](https://example.com)`)
-- Same, you can change the footnote settings: 
-    - `Keep` : Don't change the footnote (so they will be in the strange format of Obsidian turndown: `footnote[[1]](#fn-1-xxx)`)
-    - `Remove all` : Remove all the footnotes, and keep only the alias (so `footnote[[1]](#fn-1-xxx)` will be `footnote`)
-    - `Format as [^1]`: Convert `footnote[[1]](#fn-1-xxx)` to `footnote[^1]` 
-  These settings will also fix the "markdown contents," aka the footnote at the end of the documents. 
-  > **Info**  
-  > With the **format** option, if you copy multiple footnote, they will be `[^1]:` `[^2]:` etc..., not a numbered list!
-- Unconventional markdown: 
+  - `Keep` : Don't change the link (so they will be in `[link](url)` format)
+  - `Remove all` : Remove all the links, and keep only the alias (so `[link](url)` will be `link`)
+  - `Remove only for internal links` : Remove only the internal links (so `[link](url)` will be `link` but `[link](https://example.com)` will be `[link](https://example.com)`)
+- Same, you can change the footnote settings:
+  - `Keep` : Don't change the footnote (so they will be in the strange format of Obsidian turndown: `footnote[[1]](#fn-1-xxx)`)
+  - `Remove all` : Remove all the footnotes, and keep only the alias (so `footnote[[1]](#fn-1-xxx)` will be `footnote`)
+  - `Format as [^1]`: Convert `footnote[[1]](#fn-1-xxx)` to `footnote[^1]`
+    These settings will also fix the "markdown contents," aka the footnote at the end of the documents.
+    > **Info**  
+    > With the **format** option, if you copy multiple footnote, they will be `[^1]:` `[^2]:` etc..., not a numbered list!
+- Unconventional markdown:
   - Highlight: Remove `==` around the highlighted text
   - Fix callout:
-    - `Obsidian format` : Keep the same format 
+    - `Obsidian format` : Keep the same format
     - `Type to strong` : Convert all in blockquote and transform the type to bold: `> [!info]` will become `> **Info**` (à la GitHub Callout)
     - `Simple blockquote` : Remove type, keep title and convert to blockquote.
 - Other:
   - Strict line breaks: Add two spaces at the end of each line
-- Regex replacement: You can add more replacement to the copy with the button that will open a modal. Note that the replacement will be done **after all other changes**. 
+- Regex replacement: You can add more replacement to the copy with the button that will open a modal. Note that the replacement will be done **after all other changes**.
 
 ### Not common settings
+
 #### Reading view
 
 - You can copy to HTML but it will disable all the other options.
@@ -74,12 +78,11 @@ It is done on purpose to prevent surprise when you use the plugin on editing vie
 #### Editing view
 
 - Convert wikilinks to Markdown links: Convert `[[link]]` to `[link](link)`. Needed to convert the links (as in reading view).
-- Convert tabulation to space and choose the size 
-
+- Convert tabulation to space and choose the size
 
 ## 📝 Limitations
 
-- For a strange reason, the first line of a blockquote / list / callout is not selected totally properly as HTML. If you want to format only a part of this, you need to select the line before (or after). You can use "invisible" characters, `$~~$` for example. 
+- For a strange reason, the first line of a blockquote / list / callout is not selected totally properly as HTML. If you want to format only a part of this, you need to select the line before (or after). You can use "invisible" characters, `$~~$` for example.
 - Not support Mathjax copying (as you can't select them in reading view).
 - In reading view, already "HTML writing" are not copied as HTML (like `<b>…</b>`). They are copied as markdown, or only the text is copied (if not basic html). You can prevent this using the `data-type="html"` attribute on the element. For example, `b data-type="html"` will be copied as `<b>…</b>`.
 - Selecting text with image will copy the name of the image. If you want to copy the image, you need to select the image itself (not the text).
@@ -89,10 +92,10 @@ It is done on purpose to prevent surprise when you use the plugin on editing vie
 - [ ] From Obsidian's community plugins
 - [x] Using BRAT with `https://github.com/Lisandra-dev/obsidian-enhanced-copy`
 - [x] From the release page:
-    - Download the latest release
-    - Unzip `obsidian-enhanced-copy.zip` in `.obsidian/plugins/` path
-    - In Obsidian settings, reload the plugin
-    - Enable the plugin
+  - Download the latest release
+  - Unzip `obsidian-enhanced-copy.zip` in `.obsidian/plugins/` path
+  - In Obsidian settings, reload the plugin
+  - Enable the plugin
 
 ## 🤖 Developing
 
@@ -117,10 +120,8 @@ pnpm run dev
 pnpm run build
 ```
 
-
 > **Note**  
 > You can use the `.env` file with adding the key `VAULT_DEV` to specify the path to your Obsidian (development) vault. This will allow you to test your plugin without specify each times the path to the vault.
-
 
 ### 📤 Export
 
@@ -137,6 +138,7 @@ VAULT_DEV=path/to/dev/vault
 - [x] French
 
 To add a translation:
+
 - Fork the repository
 - Add the translation in the `src/i18n/locales` folder with the name of the language (ex: `fr.json`)
 - Copy the content of the [`en.json`](./src/i18n/locales/en.json) file in the new file

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -43,7 +43,7 @@
     "title": "Edit"
   },
   "global": {
-    "copy": "Copy settings between view",
+    "copy": "Copy settings between profile",
     "title": "General parameters"
   },
   "hardBreaks": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -43,7 +43,7 @@
     "title": "Édition"
   },
   "global": {
-    "copy": "Copier les paramètres entre les vues",
+    "copy": "Copier les paramètres entre les profiles",
     "title": "Paramètres généraux"
   },
   "hardBreaks": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -157,38 +157,41 @@ export default class EnhancedCopy extends Plugin {
 					navigator.clipboard.writeText(this.enhancedCopy());
 				}
 			});
-		} else if (this.settings.separateHotkey && this.settings.applyingTo === ApplyingToView.all) {
-			this.addCommand({
-				id: "copy-editor-in-markdown",
-				name: i18next.t("commands.editor"),
-				editorCallback: (editor) => {
-					let selectedText = copySelectionRange(editor, this);
-					if (selectedText && selectedText.trim().length > 0) {
-						selectedText = convertEditMarkdown(selectedText, this.settings.editing, this);
-						navigator.clipboard.writeText(selectedText);
-					}
-				}
-			});
-
-			this.addCommand({
-				id: "copy-reading-in-markdown",
-				name: i18next.t("commands.reading"),
-				checkCallback: (checking: boolean) => {
-					const view = this.app.workspace.getActiveViewOfType(MarkdownView);
-					const readingMode = view && view.getMode() !== "source";
-					if (readingMode) {
-						if (!checking) {
-							let selectedText = getSelectionAsHTML(this.settings.reading);
-							if (!this.settings.exportAsHTML) {
-								selectedText = convertMarkdown(selectedText, this.settings.reading, this);
-							}
+		} else if (this.settings.separateHotkey) {
+			if (this.settings.applyingTo === ApplyingToView.all || this.settings.applyingTo === ApplyingToView.edit) {
+				this.addCommand({
+					id: "copy-editor-in-markdown",
+					name: i18next.t("commands.editor"),
+					editorCallback: (editor) => {
+						let selectedText = copySelectionRange(editor, this);
+						if (selectedText && selectedText.trim().length > 0) {
+							selectedText = convertEditMarkdown(selectedText, this.settings.editing, this);
 							navigator.clipboard.writeText(selectedText);
 						}
-						return true;
 					}
-					return false;
-				}
-			});
+				});
+			}
+			if (this.settings.applyingTo === ApplyingToView.all || this.settings.applyingTo === ApplyingToView.reading) {
+				this.addCommand({
+					id: "copy-reading-in-markdown",
+					name: i18next.t("commands.reading"),
+					checkCallback: (checking: boolean) => {
+						const view = this.app.workspace.getActiveViewOfType(MarkdownView);
+						const readingMode = view && view.getMode() !== "source";
+						if (readingMode) {
+							if (!checking) {
+								let selectedText = getSelectionAsHTML(this.settings.reading);
+								if (!this.settings.exportAsHTML) {
+									selectedText = convertMarkdown(selectedText, this.settings.reading, this);
+								}
+								navigator.clipboard.writeText(selectedText);
+							}
+							return true;
+						}
+						return false;
+					}
+				});
+			}
 
 			this.addCommand({
 				id: "copy-other-in-markdown",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -165,9 +165,9 @@ export class EnhancedCopySettingTab extends PluginSettingTab {
 			//remove all previous profile
 			this.TABS = this.TABS.filter((tab) => tab.id !== profile.name);
 			this.TABS.push({
-				name: profile.name ?? "truc",
+				name: profile.name ?? "profile",
 				id: profile.name ?? "profile",
-				icon: "code"
+				icon: "layers-2"
 			});
 		}
 		this.TABS = [...new Set(this.TABS)];

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -301,33 +301,35 @@ export class EnhancedCopySettingTab extends PluginSettingTab {
 						this.display();
 					});
 			});
-		if (this.settings.applyingTo === ApplyingToView.all) {
-			new Setting(this.settingsPage)
-				.setName(i18next.t("hotkey.title"))
-				.setDesc(i18next.t("hotkey.desc"))
-				.addToggle((toggle) => {
-					toggle
-						.setValue(this.settings.separateHotkey)
-						.onChange(async (value) => {
-							this.settings.separateHotkey = value;
-							await this.plugin.saveSettings();
-							this.renderSettingsPage("global");
-						});
-				});
+		
+		new Setting(this.settingsPage)
+			.setName(i18next.t("hotkey.title"))
+			.setDesc(i18next.t("hotkey.desc"))
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.settings.separateHotkey)
+					.onChange(async (value) => {
+						this.settings.separateHotkey = value;
+						await this.plugin.saveSettings();
+						this.renderSettingsPage("global");
+					});
+			});
 
-			new Setting(this.settingsPage)
-				.addButton((button) => {
-					button
-						.setButtonText(i18next.t("global.copy"))
-						.onClick(async () => {
-							new EnhancedCopyViewModal(this.app, this.settings, (result) => {
-								this.settings = result;
-								this.plugin.saveSettings();
-								this.display();
-							}).open();
-						});
-				});
-		}
+		new Setting(this.settingsPage)
+			.addButton((button) => {
+				button
+					.setButtonText(i18next.t("global.copy"))
+					.onClick(async () => {
+						new EnhancedCopyViewModal(this.app, this.settings, (result) => {
+							this.settings = result;
+							this.plugin.saveSettings();
+							this.display();
+						}).open();
+					})
+					.buttonEl.classList.add("full-width");
+			})
+			.infoEl.classList.add("hide-info");
+		
 
 
 		new Setting(this.settingsPage)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Nouvelles fonctionnalités**
	- Ajout de la capacité à remplacer la copie native pour chaque vue séparément.
	- Introduction du concept de création de profils pour différents scénarios de copie.
	- Amélioration des paramètres pour les liens, les notes de bas de page, le markdown non conventionnel et les remplacements par expressions régulières.
	- Fourniture d'options pour la copie dans les vues de lecture et d'édition avec des fonctionnalités spécifiques.
- **Corrections de bugs**
	- Noté des limitations liées aux problèmes de formatage et à la copie de Mathjax.
- **Documentation**
	- Mise à jour des instructions d'installation et de développement pour le plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->